### PR TITLE
New command with merged client and distro

### DIFF
--- a/client/registration.go
+++ b/client/registration.go
@@ -19,6 +19,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+var registrationChanges chan bool
+
 func getRegByID(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
@@ -174,6 +176,7 @@ func addReg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
+	notifyRegistrationChange()
 }
 
 func updateReg(w http.ResponseWriter, r *http.Request) {
@@ -208,6 +211,7 @@ func updateReg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+	notifyRegistrationChange()
 }
 
 func delRegByID(w http.ResponseWriter, r *http.Request) {
@@ -225,6 +229,7 @@ func delRegByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+	notifyRegistrationChange()
 }
 
 func delRegByName(w http.ResponseWriter, r *http.Request) {
@@ -242,4 +247,15 @@ func delRegByName(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+	notifyRegistrationChange()
+}
+
+func SetNotification(ch chan bool) {
+	registrationChanges = ch
+}
+
+func notifyRegistrationChange() {
+	if registrationChanges != nil {
+		registrationChanges <- true
+	}
 }

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -70,6 +70,10 @@ func main() {
 
 	errs := make(chan error, 2)
 
+	registrationChanges := make(chan bool, 2)
+	client.SetNotification(registrationChanges)
+	distro.SetNotification(registrationChanges)
+
 	go func() {
 		p := fmt.Sprintf(":%d", cfg.ClientPort)
 		logger.Info("Starting Export Client", zap.String("url", p))

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2017 Mainflux
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/drasko/edgex-export/client"
+	"github.com/drasko/edgex-export/distro"
+	"github.com/drasko/edgex-export/mongo"
+
+	"go.uber.org/zap"
+	"gopkg.in/mgo.v2"
+)
+
+const (
+	clientPort             int    = 48071
+	distroPort             int    = 48070
+	defMongoURL            string = "0.0.0.0"
+	defMongoUsername       string = ""
+	defMongoPassword       string = ""
+	defMongoDatabase       string = "coredata"
+	defMongoPort           int    = 27017
+	defMongoConnectTimeout int    = 120000
+	defMongoSocketTimeout  int    = 60000
+	envMongoURL            string = "EXPORT_MONGO_URL"
+)
+
+type config struct {
+	ClientPort          int
+	DistroPort          int
+	MongoURL            string
+	MongoUser           string
+	MongoPass           string
+	MongoDatabase       string
+	MongoPort           int
+	MongoConnectTimeout int
+	MongoSocketTimeout  int
+}
+
+func main() {
+	cfg := loadConfig()
+
+	logger, _ := zap.NewProduction()
+	defer logger.Sync()
+
+	client.InitLogger(logger)
+	distro.InitLogger(logger)
+
+	ms, err := connectToMongo(cfg)
+	if err != nil {
+		logger.Error("Failed to connect to Mongo.", zap.Error(err))
+		return
+	}
+	defer ms.Close()
+
+	repo := mongo.NewRepository(ms)
+	client.InitMongoRepository(repo)
+	distro.InitMongoRepository(repo)
+
+	errs := make(chan error, 2)
+
+	go func() {
+		p := fmt.Sprintf(":%d", cfg.ClientPort)
+		logger.Info("Starting Export Client", zap.String("url", p))
+		errs <- http.ListenAndServe(p, client.HTTPServer())
+	}()
+
+	go func() {
+		p := fmt.Sprintf(":%d", cfg.DistroPort)
+		logger.Info("Starting Export distro", zap.String("url", p))
+		errs <- http.ListenAndServe(p, distro.HTTPServer())
+	}()
+
+	go func() {
+		c := make(chan os.Signal)
+		signal.Notify(c, syscall.SIGINT)
+		errs <- fmt.Errorf("%s", <-c)
+	}()
+
+	distro.Loop(repo, errs)
+
+	logger.Info("terminated")
+}
+
+func loadConfig() *config {
+	return &config{
+		ClientPort:          clientPort,
+		DistroPort:          distroPort,
+		MongoURL:            env(envMongoURL, defMongoURL),
+		MongoUser:           defMongoUsername,
+		MongoPass:           defMongoPassword,
+		MongoDatabase:       defMongoDatabase,
+		MongoPort:           defMongoPort,
+		MongoConnectTimeout: defMongoConnectTimeout,
+		MongoSocketTimeout:  defMongoSocketTimeout,
+	}
+}
+
+func env(key, fallback string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}
+
+func connectToMongo(cfg *config) (*mgo.Session, error) {
+	mongoDBDialInfo := &mgo.DialInfo{
+		Addrs:    []string{cfg.MongoURL + ":" + strconv.Itoa(cfg.MongoPort)},
+		Timeout:  time.Duration(cfg.MongoConnectTimeout) * time.Millisecond,
+		Database: cfg.MongoDatabase,
+		Username: cfg.MongoUser,
+		Password: cfg.MongoPass,
+	}
+
+	ms, err := mgo.DialWithInfo(mongoDBDialInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	ms.SetSocketTimeout(time.Duration(cfg.MongoSocketTimeout) * time.Millisecond)
+	ms.SetMode(mgo.Monotonic, true)
+
+	return ms, nil
+}

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -23,6 +23,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var registrationChanges chan bool
+
 // To be removed when any other formater is implemented
 type dummyFormat struct {
 }
@@ -157,6 +159,8 @@ func Loop(repo *mongo.Repository, errChan chan error) {
 			}
 			logger.Info("exit msg", zap.Error(e))
 			return
+		case <-registrationChanges:
+			logger.Info("Registration changes")
 
 		case <-time.After(time.Millisecond / 10):
 			// Simulate receiving 10k events/seg
@@ -166,4 +170,8 @@ func Loop(repo *mongo.Repository, errChan chan error) {
 			}
 		}
 	}
+}
+
+func SetNotification(ch chan bool) {
+	registrationChanges = ch
 }

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -35,6 +35,14 @@ func (dummy dummyFormat) Format( /*event*/ ) []byte {
 
 var dummy dummyFormat
 
+func newRegistrationInfo() *RegistrationInfo {
+	reg := &RegistrationInfo{}
+
+	reg.chRegistration = make(chan *export.Registration)
+	reg.chEvent = make(chan bool)
+	return reg
+}
+
 func (reg *RegistrationInfo) update(newReg export.Registration) bool {
 	reg.registration = newReg
 
@@ -90,9 +98,6 @@ func (reg *RegistrationInfo) update(newReg export.Registration) bool {
 		return false
 	}
 
-	reg.chRegistration = make(chan *RegistrationInfo)
-	reg.chEvent = make(chan bool)
-
 	return true
 }
 
@@ -114,10 +119,13 @@ func (reg RegistrationInfo) processEvent( /*event*/ ) {
 	}
 
 	reg.sender.Send(encrypted)
+	logger.Debug("Sent event with registration:",
+		zap.String("Name", reg.registration.Name))
 }
 
-func registrationLoop(reg RegistrationInfo) {
-	logger.Info("registration loop started")
+func registrationLoop(reg *RegistrationInfo) {
+	logger.Info("registration loop started",
+		zap.String("Name", reg.registration.Name))
 	for {
 		select {
 		case /*event :=*/ <-reg.chEvent:
@@ -125,10 +133,52 @@ func registrationLoop(reg RegistrationInfo) {
 
 		case newReg := <-reg.chRegistration:
 			if newReg == nil {
-				logger.Info("Terminate registration goroutine")
+				logger.Info("Terminating registration goroutine")
+				return
 			} else {
-				// TODO implement updating the registration info.
-				logger.Info("Registration updated")
+				if reg.update(*newReg) {
+					logger.Info("Registration updated: OK",
+						zap.String("Name", reg.registration.Name))
+				} else {
+					logger.Info("Registration updated: KO",
+						zap.String("Name", reg.registration.Name))
+					// TODO Something went wrong, need to remove this from
+					// running registrations
+				}
+			}
+		}
+	}
+}
+
+func updateRunningRegistrations(running map[string]*RegistrationInfo,
+	newRegistrations []export.Registration) {
+
+	// kill all running registrations not in the new list
+	for k, v := range running {
+		toDelete := true
+		for i := range newRegistrations {
+			if v.registration.Name == newRegistrations[i].Name {
+				toDelete = false
+				break
+			}
+		}
+		if toDelete {
+			v.chRegistration <- nil
+			delete(running, k)
+		}
+	}
+
+	// Create or update registrations in the new list
+	for i := range newRegistrations {
+		v, found := running[newRegistrations[i].Name]
+		if found {
+			v.chRegistration <- &newRegistrations[i]
+		} else {
+			// Create new goroutine for this registration
+			reg := newRegistrationInfo()
+			if reg.update(newRegistrations[i]) {
+				running[reg.registration.Name] = reg
+				go registrationLoop(reg)
 			}
 		}
 	}
@@ -137,36 +187,33 @@ func registrationLoop(reg RegistrationInfo) {
 // Loop - registration loop
 func Loop(repo *mongo.Repository, errChan chan error) {
 
-	var registrations []RegistrationInfo
+	registrations := make(map[string]*RegistrationInfo)
 
-	sourceReg := getRegistrations(repo)
-
-	for i := range sourceReg {
-		var reg RegistrationInfo
-		if reg.update(sourceReg[i]) {
-			registrations = append(registrations, reg)
-			go registrationLoop(reg)
-		}
-	}
+	updateRunningRegistrations(registrations, getRegistrations(repo))
 
 	logger.Info("Starting registration loop")
 	for {
 		select {
 		case e := <-errChan:
 			// kill all registration goroutines
-			for r := range registrations {
-				registrations[r].chRegistration <- nil
+			for k, v := range registrations {
+				v.chRegistration <- nil
+				delete(registrations, k)
 			}
 			logger.Info("exit msg", zap.Error(e))
 			return
 		case <-registrationChanges:
+			// kill all running registrations not in the new list
 			logger.Info("Registration changes")
+			updateRunningRegistrations(registrations, getRegistrations(repo))
 
-		case <-time.After(time.Millisecond / 10):
+		case <-time.After(time.Second):
 			// Simulate receiving 10k events/seg
-			for r := range registrations {
+			for _, r := range registrations {
 				// TODO only sent event if it is not blocking
-				registrations[r].chEvent <- true
+				logger.Debug("sending event",
+					zap.String("Name", r.registration.Name))
+				r.chEvent <- true
 			}
 		}
 	}

--- a/distro/types.go
+++ b/distro/types.go
@@ -35,7 +35,7 @@ type RegistrationInfo struct {
 	encrypt      Transformer
 	sender       Sender
 
-	chRegistration chan *RegistrationInfo
+	chRegistration chan *export.Registration
 
 	// TODO To be changed to event
 	chEvent chan bool


### PR DESCRIPTION
There are still issues with some corner cases with the live update of registrations, but can be solved later.

The channel added to client could be used for client and export commands. In export is used to reload the registrations from mongo and in client could be used to notify distro (not implemented in this PR)
