### PR TITLE
Use a different mqtt client id for each connection

### DIFF
--- a/distro/mqtt.go
+++ b/distro/mqtt.go
@@ -9,11 +9,11 @@
 package distro
 
 import (
-	"math/rand"
 	"strconv"
 
 	"github.com/drasko/edgex-export"
 	MQTT "github.com/eclipse/paho.mqtt.golang"
+	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
 )
 
@@ -27,7 +27,9 @@ const topic = "EdgeX"
 
 // NewMqttSender - create new mqtt sender
 func NewMqttSender(addr export.Addressable) Sender {
-	clientStr := clientID + "_" + strconv.FormatInt(rand.Int63(), 16)
+	// ClientId needs to be unique for each connection, otherwise the broker can
+	// close previous connection with the same id
+	clientStr := clientID + "_" + uuid.NewV4().String()
 
 	opts := MQTT.NewClientOptions()
 	// CHN: Should be added protocol from Addressable instead of include it the address param.

--- a/distro/mqtt.go
+++ b/distro/mqtt.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/drasko/edgex-export"
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
 )
 
@@ -22,21 +21,14 @@ type mqttSender struct {
 	topic  string
 }
 
-const clientID = "edgex"
-const topic = "EdgeX"
-
 // NewMqttSender - create new mqtt sender
 func NewMqttSender(addr export.Addressable) Sender {
-	// ClientId needs to be unique for each connection, otherwise the broker can
-	// close previous connection with the same id
-	clientStr := clientID + "_" + uuid.NewV4().String()
-
 	opts := MQTT.NewClientOptions()
 	// CHN: Should be added protocol from Addressable instead of include it the address param.
 	// CHN: We will maintain this behaviour for compatibility with Java
 	broker := addr.Address + ":" + strconv.Itoa(addr.Port)
 	opts.AddBroker(broker)
-	opts.SetClientID(clientStr)
+	opts.SetClientID(addr.Publisher)
 	opts.SetUsername(addr.User)
 	opts.SetPassword(addr.Password)
 	opts.SetAutoReconnect(false)

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,8 @@
 hash: cef7b6581e24e6f3ad3631716fe0976468b6ce66e4c63e12bf5a6a9c964bb446
-updated: 2017-11-02T14:47:23.22342649+01:00
+updated: 2017-10-13T16:47:58.453647607+13:00
 imports:
-- name: github.com/eclipse/paho.mqtt.golang
-  version: 65f43bda5f7edbbf6b7533d3a5a13b2c67cf3545
-  subpackages:
-  - packets
 - name: github.com/go-zoo/bone
   version: fd0aebc74e908868b09ac140fb5a53cb363884c1
-- name: github.com/satori/go.uuid
-  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/multierr
@@ -21,11 +15,6 @@ imports:
   - internal/color
   - internal/exit
   - zapcore
-- name: golang.org/x/net
-  version: ea0da6f35caf3ff91581c800469e22eef75076f4
-  subpackages:
-  - proxy
-  - websocket
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,14 @@
 hash: cef7b6581e24e6f3ad3631716fe0976468b6ce66e4c63e12bf5a6a9c964bb446
-updated: 2017-10-13T16:47:58.453647607+13:00
+updated: 2017-11-02T14:47:23.22342649+01:00
 imports:
+- name: github.com/eclipse/paho.mqtt.golang
+  version: 65f43bda5f7edbbf6b7533d3a5a13b2c67cf3545
+  subpackages:
+  - packets
 - name: github.com/go-zoo/bone
   version: fd0aebc74e908868b09ac140fb5a53cb363884c1
+- name: github.com/satori/go.uuid
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/multierr
@@ -15,6 +21,11 @@ imports:
   - internal/color
   - internal/exit
   - zapcore
+- name: golang.org/x/net
+  version: ea0da6f35caf3ff91581c800469e22eef75076f4
+  subpackages:
+  - proxy
+  - websocket
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:


### PR DESCRIPTION
There could only be one connection to a mqtt broker with the same id. Adding some randomness to the id