### PR TITLE
Fixed encryption path. Fixed structs to be parsed correctly from mongo

### DIFF
--- a/distro/encryption.go
+++ b/distro/encryption.go
@@ -22,6 +22,11 @@ type aesEncryption struct {
 	iv  string
 }
 
+// IV and KEY must be 16 bytes
+const (
+	blockSize = 16
+)
+
 func NewAESEncryption(encData export.EncryptionDetails) Transformer {
 	aesData := aesEncryption{
 		key: encData.Key,
@@ -37,14 +42,14 @@ func pkcs5Padding(ciphertext []byte, blockSize int) []byte {
 }
 
 func (aesData aesEncryption) Transform(data []byte) []byte {
-	iv := make([]byte, 16)
+	iv := make([]byte, blockSize)
 	copy(iv, []byte(aesData.iv))
 
 	hash := sha1.New()
 
 	hash.Write([]byte((aesData.key)))
 	key := hash.Sum(nil)
-	key = key[:16]
+	key = key[:blockSize]
 
 	block, err := aes.NewCipher(key)
 	if err != nil {

--- a/distro/encryption.go
+++ b/distro/encryption.go
@@ -19,13 +19,13 @@ import (
 
 type aesEncryption struct {
 	key string
-	iv  []byte
+	iv  string
 }
 
 func NewAESEncryption(encData export.EncryptionDetails) Transformer {
 	aesData := aesEncryption{
 		key: encData.Key,
-		iv:  []byte(encData.InitVector[:16]),
+		iv:  encData.InitVector,
 	}
 	return aesData
 }
@@ -37,6 +37,8 @@ func pkcs5Padding(ciphertext []byte, blockSize int) []byte {
 }
 
 func (aesData aesEncryption) Transform(data []byte) []byte {
+	iv := make([]byte, 16)
+	copy(iv, []byte(aesData.iv))
 
 	hash := sha1.New()
 
@@ -50,12 +52,12 @@ func (aesData aesEncryption) Transform(data []byte) []byte {
 		return nil
 	}
 
-	encodedData := []byte(base64.StdEncoding.EncodeToString(data))
-
-	ecb := cipher.NewCBCEncrypter(block, aesData.iv[:16])
-	content := pkcs5Padding(encodedData, block.BlockSize())
+	ecb := cipher.NewCBCEncrypter(block, iv)
+	content := pkcs5Padding(data, block.BlockSize())
 	crypted := make([]byte, len(content))
 	ecb.CryptBlocks(crypted, content)
 
-	return crypted
+	encodedData := []byte(base64.StdEncoding.EncodeToString(crypted))
+
+	return encodedData
 }

--- a/distro/encryption.go
+++ b/distro/encryption.go
@@ -23,9 +23,7 @@ type aesEncryption struct {
 }
 
 // IV and KEY must be 16 bytes
-const (
-	blockSize = 16
-)
+const blockSize = 16
 
 func NewAESEncryption(encData export.EncryptionDetails) Transformer {
 	aesData := aesEncryption{

--- a/distro/encryption_test.go
+++ b/distro/encryption_test.go
@@ -21,6 +21,7 @@ const (
 	plainString = "This is the test string used for testing"
 	iv          = "123456789012345678901234567890"
 	key         = "aquqweoruqwpeoruqwpoeruqwpoierupqoweiurpoqwiuerpqowieurqpowieurpoqiweuroipwqure"
+	blockSize   = 16
 )
 
 func aesDecrypt(crypt []byte, aesData export.EncryptionDetails) []byte {
@@ -28,9 +29,9 @@ func aesDecrypt(crypt []byte, aesData export.EncryptionDetails) []byte {
 
 	hash.Write([]byte((aesData.Key)))
 	key := hash.Sum(nil)
-	key = key[:16]
+	key = key[:blockSize]
 
-	iv := make([]byte, 16)
+	iv := make([]byte, blockSize)
 	copy(iv, []byte(aesData.InitVector))
 
 	block, err := aes.NewCipher(key)

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -110,7 +110,6 @@ func (reg RegistrationInfo) processEvent(event *export.Event) {
 	if reg.encrypt != nil {
 		encrypted = reg.encrypt.Transform(compressed)
 	}
-
 	reg.sender.Send(encrypted)
 }
 
@@ -161,7 +160,7 @@ func Loop(repo *mongo.Repository, errChan chan error) {
 		case <-time.After(time.Second):
 			// Simulate receiving events
 			event := getNextEvent()
-			logger.Info("Event: ", zap.Int("length", len(registrations)))
+			logger.Info("Event: ", zap.Any("event", event), zap.Int("length", len(registrations)))
 
 			for r := range registrations {
 				// TODO only sent event if it is not blocking

--- a/encryption.go
+++ b/encryption.go
@@ -17,7 +17,7 @@ const (
 // EncryptionDetails - Provides details for encryption
 // of export data per client request
 type EncryptionDetails struct {
-	Algo       string
-	Key        string
-	InitVector string
+	Algo       string `bson:"encryptionAlgorithm,omitempty" json:"encryptionAlgorithm,omitempty"`
+	Key        string `bson:"encryptionKey,omitempty" json:"encryptionKey,omitempty"`
+	InitVector string `bson:"initializingVector,omitempty" json:"initializingVector,omitempty"`
 }

--- a/message.go
+++ b/message.go
@@ -15,15 +15,21 @@ type Message struct {
 
 // Event - packet of Readings
 type Event struct {
-	Pushed   int64
-	Device   string
-	Readings []Reading
+	Pushed   int64     `json:"pushed,omitempty"`
+	Device   string    `json:"device,omitempty"`
+	Readings []Reading `json:"readings,omitempty"`
+	Created  int64     `json:"created,omitempty"`
+	Modified int64     `json:"modified,omitempty"`
+	Origin   int64     `json:"origin,omitempty"`
 }
 
 // Reading - Sensor measurement
 type Reading struct {
-	Pushed int64
-	Name   string
-	Value  string
-	Device string
+	Pushed   int64  `json:"pushed,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Value    string `json:"value,omitempty"`
+	Device   string `json:"device,omitempty"`
+	Created  int64  `json:"created,omitempty"`
+	Modified int64  `json:"modified,omitempty"`
+	Origin   int64  `json:"origin,omitempty"`
 }

--- a/registration.go
+++ b/registration.go
@@ -6,6 +6,10 @@
 
 package export
 
+import (
+	"gopkg.in/mgo.v2/bson"
+)
+
 // Compression algorithm types
 const (
 	CompNone = "NONE"
@@ -35,7 +39,7 @@ const (
 // Registration - Defines the registration details
 // on the part of north side export clients
 type Registration struct {
-	ID          string            `json:"_id,omitempty"`
+	ID          bson.ObjectId     `bson:"_id,omitempty" json:"_id,omitempty"`
 	Created     int64             `json:"created,omitempty"`
 	Modified    int64             `json:"modified,omitempty"`
 	Origin      int64             `json:"origin,omitempty"`


### PR DESCRIPTION
My previous PR regarding encryption worked well with the test but it was failing because when we do the query to database, it was not being parsed correctly and encryption data was not being set correctly. This PR fixes that. 

Signed-off-by: chencho <smunoz@cavium.com>