### PR TITLE
Use constants for building reference reply

### DIFF
--- a/client/registration.go
+++ b/client/registration.go
@@ -66,14 +66,14 @@ func getRegList(w http.ResponseWriter, r *http.Request) {
 
 	switch t {
 	case "algorithms":
-		l = `["None","Aes"]`
+		l = `["` + export.EncNone + `"," ` + export.EncAes + `"]`
 	case "compressions":
-		l = `["None","Gzip","Zip"]`
+		l = `["` + export.CompNone + `","` + export.CompGzip + `","` +
+			export.CompZip + `"]`
 	case "formats":
-		l = `["JSON","XML","Serialized","IotCoreJSON","AzureJSON","CSV"]`
+		l = `["` + export.FormatJSON + `","` + export.FormatXML + `"]`
 	case "destinations":
-		l = `["DestMQTT", "TeDestZMQller", "DestIotCoreMQTT,
-			"DestAzureMQTT", "DestRest"]`
+		l = `["` + export.DestMQTT + `", "` + export.DestRest + `"]`
 	default:
 		logger.Error("Unknown type: " + t)
 		w.WriteHeader(http.StatusBadRequest)

--- a/client/registration.go
+++ b/client/registration.go
@@ -62,18 +62,22 @@ func getRegList(w http.ResponseWriter, r *http.Request) {
 
 	t := bone.GetValue(r, "type")
 
-	var l string
+	var list []string
 
 	switch t {
 	case "algorithms":
-		l = `["` + export.EncNone + `"," ` + export.EncAes + `"]`
+		list = append(list, export.EncNone)
+		list = append(list, export.EncAes)
 	case "compressions":
-		l = `["` + export.CompNone + `","` + export.CompGzip + `","` +
-			export.CompZip + `"]`
+		list = append(list, export.CompNone)
+		list = append(list, export.CompGzip)
+		list = append(list, export.CompZip)
 	case "formats":
-		l = `["` + export.FormatJSON + `","` + export.FormatXML + `"]`
+		list = append(list, export.FormatJSON)
+		list = append(list, export.FormatXML)
 	case "destinations":
-		l = `["` + export.DestMQTT + `", "` + export.DestRest + `"]`
+		list = append(list, export.DestMQTT)
+		list = append(list, export.DestRest)
 	default:
 		logger.Error("Unknown type: " + t)
 		w.WriteHeader(http.StatusBadRequest)
@@ -81,8 +85,16 @@ func getRegList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	res, err := json.Marshal(list)
+	if err != nil {
+		logger.Error("Failed to generate json", zap.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, err.Error())
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
-	io.WriteString(w, l)
+	io.WriteString(w, string(res))
 }
 
 func getAllReg(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Use the existing constants for building the reply. Removed from the reply not yet implemented as described in:
https://github.com/edgexfoundry/export-client/blob/9823b243ebd0d4bf059890dd841da77c99969116/src/test/resources/raml/export-client.raml#L134
