### PR TITLE
Add zeromq support with a build tag

### DIFF
--- a/cmd/distro/main.go
+++ b/cmd/distro/main.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/drasko/edgex-export"
 	"github.com/drasko/edgex-export/distro"
 
 	"go.uber.org/zap"
@@ -56,6 +57,7 @@ func main() {
 	cfg := loadConfig()
 
 	errs := make(chan error, 2)
+	eventCh := make(chan *export.Event, 10)
 
 	go func() {
 		p := fmt.Sprintf(":%d", cfg.Port)
@@ -69,7 +71,10 @@ func main() {
 		errs <- fmt.Errorf("%s", <-c)
 	}()
 
-	distro.Loop(errs)
+	// There can be another receivers that can be initialiced here
+	distro.ZeroMQReceiver(eventCh)
+
+	distro.Loop(errs, eventCh)
 
 	logger.Info("terminated")
 }

--- a/distro/queue.go
+++ b/distro/queue.go
@@ -21,8 +21,12 @@ const sampleEvent string = `{"pushed":0,"device":"livingroomthermostat",
 	"id":"57ed24f0502fdf73bb637917","created":1475159280762,"modified":1475159280762,"origin":1471806386919}`
 
 func getNextEvent() *export.Event {
+	return parseEvent(sampleEvent)
+}
+
+func parseEvent(str string) *export.Event {
 	event := export.Event{}
-	if err := json.Unmarshal([]byte(sampleEvent), &event); err != nil {
+	if err := json.Unmarshal([]byte(str), &event); err != nil {
 		logger.Error("Failed to query add registration", zap.Error(err))
 		return nil
 	}

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -268,19 +268,6 @@ func Loop(errChan chan error, eventCh chan *export.Event) {
 					reg.chEvent <- event
 				}
 			}
-
-			// case <-time.After(time.Second):
-			// 	// Simulate receiving events
-			// 	event := getNextEvent()
-
-			// 	for k, reg := range registrations {
-			// 		if reg.deleteMe {
-			// 			delete(registrations, k)
-			// 		} else {
-			// 			// TODO only sent event if it is not blocking
-			// 			reg.chEvent <- event
-			// 		}
-			// 	}
 		}
 	}
 }

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -9,13 +9,10 @@
 package distro
 
 // TODO:
-// - Receive events from 0mq until a new message broker/rpc is chosen
 // - Event buffer management per sender(do not block distro.Loop on full
 //   registration channel)
 
 import (
-	"time"
-
 	"github.com/drasko/edgex-export"
 	"go.uber.org/zap"
 )
@@ -214,7 +211,7 @@ func updateRunningRegistrations(running map[string]*RegistrationInfo,
 }
 
 // Loop - registration loop
-func Loop(errChan chan error) {
+func Loop(errChan chan error, eventCh chan *export.Event) {
 
 	registrations := make(map[string]*RegistrationInfo)
 
@@ -240,8 +237,6 @@ func Loop(errChan chan error) {
 		}
 	}
 
-	go initZmq()
-
 	logger.Info("Starting registration loop")
 	for {
 		select {
@@ -261,10 +256,8 @@ func Loop(errChan chan error) {
 			logger.Info("Registration changes")
 			updateRunningRegistrations(registrations, update)
 
-		case <-time.After(time.Second):
-			// Simulate receiving events
-			event := getNextEvent()
-
+		case event := <-eventCh:
+			logger.Info("EVENT")
 			for k, reg := range registrations {
 				if reg.deleteMe {
 					delete(registrations, k)
@@ -273,6 +266,19 @@ func Loop(errChan chan error) {
 					reg.chEvent <- event
 				}
 			}
+
+			// case <-time.After(time.Second):
+			// 	// Simulate receiving events
+			// 	event := getNextEvent()
+
+			// 	for k, reg := range registrations {
+			// 		if reg.deleteMe {
+			// 			delete(registrations, k)
+			// 		} else {
+			// 			// TODO only sent event if it is not blocking
+			// 			reg.chEvent <- event
+			// 		}
+			// 	}
 		}
 	}
 }

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -13,6 +13,8 @@ package distro
 //   registration channel)
 
 import (
+	"time"
+
 	"github.com/drasko/edgex-export"
 	"go.uber.org/zap"
 )

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -240,6 +240,8 @@ func Loop(errChan chan error) {
 		}
 	}
 
+	go initZmq()
+
 	logger.Info("Starting registration loop")
 	for {
 		select {

--- a/distro/zeromq.go
+++ b/distro/zeromq.go
@@ -15,7 +15,7 @@ func initZmq(eventCh chan *export.Event) {
 	defer q.Close()
 
 	logger.Info("Connecting to zmq...")
-	q.Connect("tcp://localhost:32768")
+	q.Connect("tcp://localhost:5563")
 	logger.Info("Connected to zmq")
 	q.SetSubscribe("")
 

--- a/distro/zeromq.go
+++ b/distro/zeromq.go
@@ -1,9 +1,8 @@
 package distro
 
 import (
-	"fmt"
-
 	zmq "github.com/pebbe/zmq4"
+	"go.uber.org/zap"
 )
 
 func initZmq() {
@@ -11,17 +10,22 @@ func initZmq() {
 	defer q.Close()
 
 	logger.Info("Connecting to zmq...")
-	q.Connect("tcp://localhost:5563")
+	q.Connect("tcp://localhost:32768")
 	logger.Info("Connected to zmq")
+	q.SetSubscribe("")
 
 	for {
 		msg, err := q.RecvMessage(0)
 		logger.Info("Received zmq msg")
-		if err == nil {
+		if err != nil {
 			id, _ := q.GetIdentity()
-			fmt.Println("ERROR:", msg[0], id)
+			logger.Error("Error getting mesage", zap.String("id", id))
 		} else {
-			fmt.Println("MSG  :", msg)
+			for _, str := range msg {
+				// Why the offset of 7?? zmq v3 vs v4 ?
+				event := parseEvent(str[7:])
+				logger.Debug("Event received", zap.Any("event", event))
+			}
 		}
 	}
 }

--- a/distro/zeromq.go
+++ b/distro/zeromq.go
@@ -1,11 +1,16 @@
 package distro
 
 import (
+	"github.com/drasko/edgex-export"
 	zmq "github.com/pebbe/zmq4"
 	"go.uber.org/zap"
 )
 
-func initZmq() {
+func ZeroMQReceiver(eventCh chan *export.Event) {
+	go initZmq(eventCh)
+}
+
+func initZmq(eventCh chan *export.Event) {
 	q, _ := zmq.NewSocket(zmq.SUB)
 	defer q.Close()
 
@@ -23,7 +28,8 @@ func initZmq() {
 			for _, str := range msg {
 				// Why the offset of 7?? zmq v3 vs v4 ?
 				event := parseEvent(str[7:])
-				logger.Debug("Event received", zap.Any("event", event))
+				logger.Info("Event received", zap.Any("event", event))
+				eventCh <- event
 			}
 		}
 	}

--- a/distro/zeromq.go
+++ b/distro/zeromq.go
@@ -25,7 +25,7 @@ func initZmq(eventCh chan *export.Event) {
 	defer q.Close()
 
 	logger.Info("Connecting to zmq...")
-	q.Connect("tcp://localhost:5563")
+	q.Connect("tcp://127.0.0.1:5563")
 	logger.Info("Connected to zmq")
 	q.SetSubscribe("")
 
@@ -47,15 +47,9 @@ func initZmq(eventCh chan *export.Event) {
 func parseEvent(str string) *export.Event {
 	event := export.Event{}
 
-	if err := json.Unmarshal([]byte(str), &event); err == nil {
-		return &event
-	}
-
-	// Why the offset of 7?? zmq v3 vs v4 ?
-	if err := json.Unmarshal([]byte(str[7:]), &event); err != nil {
+	if err := json.Unmarshal([]byte(str), &event); err != nil {
 		logger.Error("Failed to parse event", zap.Error(err))
 		return nil
 	}
-
 	return &event
 }

--- a/distro/zeromq.go
+++ b/distro/zeromq.go
@@ -16,7 +16,6 @@ func initZmq() {
 
 	for {
 		msg, err := q.RecvMessage(0)
-		logger.Info("Received zmq msg")
 		if err != nil {
 			id, _ := q.GetIdentity()
 			logger.Error("Error getting mesage", zap.String("id", id))

--- a/distro/zeromq.go
+++ b/distro/zeromq.go
@@ -1,0 +1,27 @@
+package distro
+
+import (
+	"fmt"
+
+	zmq "github.com/pebbe/zmq4"
+)
+
+func initZmq() {
+	q, _ := zmq.NewSocket(zmq.SUB)
+	defer q.Close()
+
+	logger.Info("Connecting to zmq...")
+	q.Connect("tcp://localhost:5563")
+	logger.Info("Connected to zmq")
+
+	for {
+		msg, err := q.RecvMessage(0)
+		logger.Info("Received zmq msg")
+		if err == nil {
+			id, _ := q.GetIdentity()
+			fmt.Println("ERROR:", msg[0], id)
+		} else {
+			fmt.Println("MSG  :", msg)
+		}
+	}
+}

--- a/distro/zeromq.go
+++ b/distro/zeromq.go
@@ -10,10 +10,16 @@ package distro
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/drasko/edgex-export"
 	zmq "github.com/pebbe/zmq4"
 	"go.uber.org/zap"
+)
+
+const (
+	dataHost   = "127.0.0.1"
+	zeroMQPort = 5563
 )
 
 func ZeroMQReceiver(eventCh chan *export.Event) {
@@ -25,7 +31,8 @@ func initZmq(eventCh chan *export.Event) {
 	defer q.Close()
 
 	logger.Info("Connecting to zmq...")
-	q.Connect("tcp://127.0.0.1:5563")
+	url := fmt.Sprintf("tcp://%s:%d", dataHost, zeroMQPort)
+	q.Connect(url)
 	logger.Info("Connected to zmq")
 	q.SetSubscribe("")
 

--- a/distro/zeromq_dummy.go
+++ b/distro/zeromq_dummy.go
@@ -3,10 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+
+// +build !zeromq
+
 package distro
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/drasko/edgex-export"
 	"go.uber.org/zap"
@@ -20,8 +24,15 @@ const sampleEvent string = `{"pushed":0,"device":"livingroomthermostat",
 	{"pushed":0,"name":"rpm","value":"58","id":"57ed24f0502fdf73bb637916","created":1475159280756,"modified":1475159280756,"origin":1471806386919}],
 	"id":"57ed24f0502fdf73bb637917","created":1475159280762,"modified":1475159280762,"origin":1471806386919}`
 
-func getNextEvent() *export.Event {
-	return parseEvent(sampleEvent)
+func ZeroMQReceiver(eventCh chan *export.Event) {
+	go func() {
+		ev := parseEvent(sampleEvent)
+		for {
+			time.Sleep(time.Second)
+			eventCh <- ev
+			logger.Info("Event generated")
+		}
+	}()
 }
 
 func parseEvent(str string) *export.Event {

--- a/message.go
+++ b/message.go
@@ -15,21 +15,21 @@ type Message struct {
 
 // Event - packet of Readings
 type Event struct {
-	Pushed   int64     `json:"pushed,omitempty"`
+	Pushed   int64     `json:"pushed"`
 	Device   string    `json:"device,omitempty"`
 	Readings []Reading `json:"readings,omitempty"`
-	Created  int64     `json:"created,omitempty"`
-	Modified int64     `json:"modified,omitempty"`
-	Origin   int64     `json:"origin,omitempty"`
+	Created  int64     `json:"created"`
+	Modified int64     `json:"modified"`
+	Origin   int64     `json:"origin"`
 }
 
 // Reading - Sensor measurement
 type Reading struct {
-	Pushed   int64  `json:"pushed,omitempty"`
+	Pushed   int64  `json:"pushed"`
 	Name     string `json:"name,omitempty"`
 	Value    string `json:"value,omitempty"`
 	Device   string `json:"device,omitempty"`
-	Created  int64  `json:"created,omitempty"`
-	Modified int64  `json:"modified,omitempty"`
-	Origin   int64  `json:"origin,omitempty"`
+	Created  int64  `json:"created"`
+	Modified int64  `json:"modified"`
+	Origin   int64  `json:"origin"`
 }

--- a/registration.go
+++ b/registration.go
@@ -40,16 +40,16 @@ const (
 // on the part of north side export clients
 type Registration struct {
 	ID          bson.ObjectId     `bson:"_id,omitempty" json:"_id,omitempty"`
-	Created     int64             `json:"created,omitempty"`
-	Modified    int64             `json:"modified,omitempty"`
-	Origin      int64             `json:"origin,omitempty"`
+	Created     int64             `json:"created"`
+	Modified    int64             `json:"modified"`
+	Origin      int64             `json:"origin"`
 	Name        string            `json:"name,omitempty"`
 	Addressable Addressable       `json:"addressable,omitempty"`
 	Format      string            `json:"format,omitempty"`
 	Filter      Filter            `json:"filter,omitempty"`
 	Encryption  EncryptionDetails `json:"encryption,omitempty"`
 	Compression string            `json:"compression,omitempty"`
-	Enable      bool              `json:"enable,omitempty"`
+	Enable      bool              `json:"enable"`
 	Destination string            `json:"destination,omitempty"`
 }
 


### PR DESCRIPTION
I don't want to add by default zeromq, as it will break cross compilation and current docker files. Compiling with:
`go run -tags zeromq main.go`
will enable the event read from zeromq. If not enabled the build tag it will use a simulated queue which generate the same event each second (same behavior prior this PR).

There is also a problem with the data read from zeromq. First 7 bytes seems to be garbage, if you skip them you get all the event json. I had the same problem with a python script reading from zeromq. So I assumed it is a zeromq v3(from core-data) vs v4.